### PR TITLE
replace stack_value_output VPCId with stack_resource_type AWS::EC2::VPC

### DIFF
--- a/bin/vpc-associate
+++ b/bin/vpc-associate
@@ -4,7 +4,7 @@
 # designed to work from the root of a Moonshot repo.
 #
 # We find all VPCs and prompt the user. We then gather the variables of:
-#   * VPCId
+#   * AWS::EC2::VPC
 #   * RouteTableID
 #   * VPCNetwork
 #
@@ -46,12 +46,12 @@ TARGET_STACKS=($(stack_list_all ${SELF_STACK_NAME}))
 TARGET_STACK_NAME=$(choose ${TARGET_STACKS[@]})
 
 echoerr "INFO: Setting ${SELF_STACK_NAME} variables"
-SELF_VPC_ID=$(stack_value_output ${SELF_STACK_NAME} VPCId)
+SELF_VPC_ID=$(stack_resource_type ${SELF_STACK_NAME} "AWS::EC2::VPC")
 SELF_VPC_NETWORK=$(stack_value_parameter ${SELF_STACK_NAME} VPCNetwork)
 SELF_VPC_ROUTE_TABLE=$(stack_value_output ${SELF_STACK_NAME} RouteTableId)
 
 echoerr "INFO: Setting ${TARGET_STACK_NAME} variables"
-TARGET_VPC_ID=$(stack_value_output ${TARGET_STACK_NAME} VPCId)
+TARGET_VPC_ID=$(stack_resource_type ${TARGET_STACK_NAME} "AWS::EC2::VPC")
 TARGET_VPC_NETWORK=$(stack_value_parameter ${TARGET_STACK_NAME} VPCNetwork)
 TARGET_VPC_ROUTE_TABLE=$(stack_value_output ${TARGET_STACK_NAME} RouteTableId)
 

--- a/bin/vpc-dissociate
+++ b/bin/vpc-dissociate
@@ -4,7 +4,7 @@
 # is designed to work from the root of a Moonshot repo.
 #
 # We find all VPCs and prompt the user. We then gather the variables of:
-#   * VPCId
+#   * AWS::EC2::VPC
 #   * RouteTableID
 #   * VPCNetwork
 #
@@ -49,7 +49,7 @@ PEERING_STATUS_CODES=(\
 # MAIN
 #
 echoerr "INFO: Setting ${SELF_STACK_NAME} variables"
-SELF_VPC_ID=$(stack_value_output ${SELF_STACK_NAME} VPCId)
+SELF_VPC_ID=$(stack_resource_type ${SELF_STACK_NAME} "AWS::EC2::VPC")
 SELF_VPC_NETWORK=$(stack_value_parameter ${SELF_STACK_NAME} VPCNetwork)
 SELF_VPC_ROUTE_TABLE=$(stack_value_output ${SELF_STACK_NAME} RouteTableId)
 

--- a/lib/aws/vpc.sh
+++ b/lib/aws/vpc.sh
@@ -5,7 +5,7 @@ vpc_id_from_stack_name () {
     # Find the VPCId for ${stack_name}
     local stack_name=$1
 
-    stack_value_output ${stack_name} VPCId
+    stack_resource_type ${stack_name} "AWS::EC2::VPC"
     return $?
 }
 


### PR DESCRIPTION
This removes a dependency on a stack needing the output of `VPCId`. This way is smarterer as it's unlikely that a person will be creating multiple VPCs with CF; but not impossible....