### PR TITLE
moon.sh: set MOON_FILE=false if the test for Moonfile.rb can be bypassed

### DIFF
--- a/bin/ami-export
+++ b/bin/ami-export
@@ -3,6 +3,8 @@
 # This script exports and AMI for usage by other CDS accounts
 #
 
+export MOON_FILE=false
+
 source $(dirname $0)/../moon.sh
 
 [[ $# == 0 ]] \

--- a/bin/instance-ip
+++ b/bin/instance-ip
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+#
+# Output Private IP of the instance
+#
+
+export MOON_FILE=false
 
 source $(dirname $0)/../moon.sh
 

--- a/bin/kms-list
+++ b/bin/kms-list
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+#
+# Detail all KMS keys available
+#
+
+export MOON_FILE=false
 
 source $(dirname $0)/../moon.sh
 

--- a/bin/puppet-module-update
+++ b/bin/puppet-module-update
@@ -6,6 +6,8 @@
 # Puppetfile in the puppet directory.
 #
 
+export MOON_FILE=false
+
 source $(dirname $0)/../moon.sh
 
 # We must be in the root of the repo else ../moon.sh would not have been sourced

--- a/bin/terminate-instance
+++ b/bin/terminate-instance
@@ -6,6 +6,8 @@
 # checks to fail, which may take many minutes, before the instance is replaced.
 #
 
+export MOON_FILE=false
+
 source $(dirname $0)/../moon.sh
 
 [[ $# -lt 1 ]] \

--- a/moon.sh
+++ b/moon.sh
@@ -84,10 +84,15 @@ if [[ ! $(basename "x$0") =~ "bash"$ ]]; then
         && echoerr "ERROR: 'AWS_REGION' is unset." \
         && exit 1
 
-    # APP_NAME is needed by the greater majority of scripts.
+    # Most scripts in bin/ build off of ${APP_NAME} which is programatically
+    # set from the Moonfile. For those that don't need APP_NAME, i.e. can be
+    # run from anywhere in the filesystem, they can set ${MOON_FILE} to false
+    # and bypass this failure mode.
     if [[ ! -f ${PWD}/Moonfile.rb ]]; then
-        echoerr "ERROR: Moonfile.rb is not present in CWD"
-        exit 1
+        if [[ ! ${MOON_FILE-} == false ]]; then
+            echoerr "ERROR: Moonfile.rb is not present in CWD"
+            exit 1
+        fi
     else
         export APP_NAME=$(grep app_name Moonfile.rb | tr -d "'" | awk '{print $NF}')
     fi


### PR DESCRIPTION
Some tools can be run from anywhere in the filesystem, most tools build from needing to know the app name of the current stack being administered.