### PR TITLE
Replace AWS_DEFAULT_PROFILE with AWS_ACCOUNT_NAME

### DIFF
--- a/bin/aws-creds
+++ b/bin/aws-creds
@@ -27,9 +27,9 @@ config = ParseConfig.new("#{ENV['HOME']}/.aws/config")
 def profiles
   STDERR.puts "Usage: #{File.basename(__FILE__)} PROFILE|show"
   STDERR.puts
-  if ENV['AWS_DEFAULT_PROFILE']
+  if ENV['AWS_ACCOUNT_NAME']
     STDERR.puts 'Current profile:'
-    STDERR.puts "  #{ENV['AWS_DEFAULT_PROFILE']}"
+    STDERR.puts "  #{ENV['AWS_ACCOUNT_NAME']}"
     STDERR.puts
   end
   STDERR.puts 'Available profiles:'
@@ -41,7 +41,8 @@ def echo_params(profile)
   # 'credentials'..
   config_profile = "profile #{profile}"
   puts "export AWS_REGION=#{@c_params[config_profile]['region']}"
-  puts "export AWS_DEFAULT_PROFILE=#{profile}"
+  # See moon.sh for why we set AWS_ACCOUNT_NAME instead of AWS_DEFAULT_PROFILE
+  puts "export AWS_ACCOUNT_NAME=#{profile}"
   puts "export AWS_ACCESS_KEY_ID=#{@p_params[profile]['aws_access_key_id']}"
   # rubocop:disable Metrics/LineLength
   puts "export AWS_SECRET_ACCESS_KEY=#{@p_params[profile]['aws_secret_access_key']}"

--- a/lib/aws/bastion.sh
+++ b/lib/aws/bastion.sh
@@ -4,7 +4,7 @@
 bastion () {
     # Only one bastion exists per AWS account inside a 'core' stack.
     # The bastion host in ~/.ssh/config must be set accordingly
-    local bastion_hostname="bastion-${AWS_DEFAULT_PROFILE}"
+    local bastion_hostname="bastion-${AWS_ACCOUNT_NAME}"
     if [[ "$(grep ${bastion_hostname} ${HOME}/.ssh/config)" == "" ]]; then
         echoerr "ERROR: You do not have configuration set for ${bastion_hostname} in ~/.ssh/config"
         exit 1

--- a/moon.sh
+++ b/moon.sh
@@ -89,11 +89,23 @@ if [[ ! $(basename "x$0") =~ "bash"$ ]]; then
     # non-zero exit codes as serious and exit.
     set -eu
 
-    # If AWS_DEFAULT_PROFILE is unset then aws-creds has most likely not been
-    # run and nothing AWS related will work; either in moonshot or moonshell.
-    # `aws-creds` sets up the credentials as MOON vars to be used by aws-cli
-    [[ -z ${AWS_DEFAULT_PROFILE-} ]] \
-        && echoerr "ERROR: 'AWS_DEFAULT_PROFILE' is unset. Try 'aws-creds'" \
+    # Originally we used AWS_DEFAULT_PROFILE to label accounts and it was used
+    # by lib/aws/bastion.sh. This was not portable because when connected to a
+    # remote host, where you have passed through AWS env vars, aws-cli commands
+    # fail because there is no ~/.aws/{config,credentials} configured.
+    # tl;dr; AWS_DEFAULT_PROFILE is reserved and should only be set where you
+    # have run `aws configure`; this is a machine local thing.
+    # 
+    # As we still need a way of differentiating accounts and hosts etc we
+    # instead set AWS_ACCOUNT_NAME. This is not currently used by aws-cli, so
+    # we appropriate it here. This should be set to the defining suffix
+    # required; for example 'production' or 'development' are used in bastion
+    # functions to set the name of the bastion to use; 'bastion-production' or
+    # 'bastion-development', which in turn should reference host entries in
+    # ~/.ssh/config
+    #
+    [[ -z ${AWS_ACCOUNT_NAME} ]] \
+        && echoerr "ERROR: 'AWS_ACCOUNT_NAME' is unset. aws-creds?" \
         && exit 1
 
     # aws-cli uses this and it enables a more dynamic environment


### PR DESCRIPTION
Putting such hefty commens in to `moon.sh` probably isn't great, but it's information where it's used.

## tl;dr;
* `AWS_DEFAULT_PROFILE` is used by awscli.
* If set, awscli looks in `~/.aws/credentials` for it.
* If set and there is no `~/.aws/credentials` file, because you have passed through `AWS_*` in ssh_config and are currently on a remote host, then all awscli commands will bork because the profile can't be found.
* We set `AWS_ACCOUNT_NAME` instead because
    * it's intuitively titled
    * Is not used by anything else anywhere
    * still enables everything to work as intended