### PR TITLE
rds_postgres_list_dbs should not fail on undef vars

### DIFF
--- a/lib/aws/rds.sh
+++ b/lib/aws/rds.sh
@@ -197,7 +197,7 @@ rds_postgres_list_dbs () {
     [[ -z ${databases[@]-} ]] && return 1
 
     for database in ${databases[@]-}; do
-        if ! contains ${database} ${POSTGRES_IGNORED_DBS[@]}; then
+        if ! contains ${database} ${POSTGRES_IGNORED_DBS[@]-}; then
             echo ${database}
         fi
     done


### PR DESCRIPTION
the `contains` function (`lib/common.sh`) has this conditional which fails gracefully when `$2` is null, so if `POSTGRES_IGNORED_DBS` is unset we can move on with life and just display all DB names.

excerpt of `contains`:
```
    [ $# -lt 2 ] \
        && echoerr "Usage: ${FUNCNAME[0]} \$SEARCH_ITEM \${BASH_ARRAY[@]}" \
        && echoerr "Returns 0 if search_item is in bash_array, 1 if not." \
        && return 1
```

Flagged as bug because `rds-list-dbs` fails horribly if the global is unset.