### PR TITLE
route53-ls

### DIFF
--- a/bin/route53-ls
+++ b/bin/route53-ls
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# List A and CNAME records from a list of available hosted zones for the
+# account you have credentials loaded for.
+#
+
+export MOON_FILE=false
+
+source ${MOON_SHELL}
+
+ACC_ID=$(sts_account_id)
+
+echoerr "INFO: Enumerating all hosted zones for account '${ACC_ID}'"
+
+HOSTED_ZONES=($(aws route53 list-hosted-zones-by-name \
+    --region ${AWS_REGION} \
+    --query 'HostedZones[].Name' \
+    --output text))
+
+HOSTED_ZONE_NAME=$(choose ${HOSTED_ZONES[@]})
+
+[[ ! ${HOSTED_ZONE_NAME-} =~ \.$ ]] \
+    && echoerr "ERROR: Hosted zone name '${HOSTED_ZONE_NAME}' is not absolute." \
+    && exit 1
+
+echoerr "INFO: Hosted Zone: ${HOSTED_ZONE_NAME}"
+
+route53_list_name ${HOSTED_ZONE_NAME}


### PR DESCRIPTION
TL;DR; list records from an internal hosted zone that you choose from a list of all hosted zones, internal and external, owned by your currently configured AWS account.

Sample output:
```
$ route53-ls 
INFO: Enumerating all hosted zones for account 'REDACTED'
  0: dev.example.com.
  1: core-dev.local.
  2: foo-dev.local.
Choice [0-2]: 1
INFO: Hosted Zone: core-dev.local.
bastion.core-dev.local.
A	10.0.4.24
logger.core-dev.local.
A	10.0.0.36
smtp.core-dev.local.
A	10.0.4.154
foo.core-dev.local.
CNAME	foo.foo-dev.local
```