### PR TITLE
Auto local sourcing

### DIFF
--- a/lib/overlay.sh
+++ b/lib/overlay.sh
@@ -19,20 +19,26 @@ overlay_dir () {
 
     local location
     for location in ${locations[@]}; do
-        [[ -d "${dir}/${location}" ]] && overlay_source_dir "${dir}/${location}"
+        [[ -d "${dir}/${location}" ]] \
+            && overlay_source_dir "${dir}/${location}" \
+            || true
     done
 }
 
 overlay_path_append () {
     local bin_dir=$1
 
-    [[ ! "${PATH}" =~ "${bin_dir}" ]] && export PATH=${PATH}:${bin_dir}
+    [[ ! "${PATH}" =~ "${bin_dir}" ]] \
+        && export PATH=${PATH}:${bin_dir} \
+        || true
 }
 
 overlay_path_prepend () {
     local bin_dir=$1
 
-    [[ ! "${PATH}" =~ "${bin_dir}" ]] && export PATH=${bin_dir}:${PATH}
+    [[ ! "${PATH}" =~ "${bin_dir}" ]] \
+        && export PATH=${bin_dir}:${PATH} \
+        || true
 }
 
 overlay_source_dir () {

--- a/moon.sh
+++ b/moon.sh
@@ -151,5 +151,8 @@ if [[ ! $(basename "x$0") =~ "bash"$ ]]; then
     # Source the rest of the things!!!
     _moonshell_source ${MOON_LIB}
     _moonshell_source ${MOON_COMPLETION}
+
+    # Auto-source the CWD
+    overlay_dir ${PWD}
 fi
 


### PR DESCRIPTION
Getting users to do things themselves is a trap, automate all the things. This enables a private moonshot based repo to contain helpers and other things needed purely for that application.

So, given that a person should only ever be in the root of a moonshell based repo and that moon.sh will only be sourced if so, this should be fine. The only time it won't is if a person is in a dir that has a {bin,etc,lib} folder outside of a moonshell based repo, in which case we will auto-source all of the things if they run a command from moonshell... which should never happen, but if it does, should not actually cause any major issues; if so a person should `export DEBUG=true` to sort shit out.