### PR TITLE
Fix _moon_self_fix_link function to correctly overwrite existing symlink

### DIFF
--- a/lib/moonshell.sh
+++ b/lib/moonshell.sh
@@ -232,7 +232,7 @@ _moonshell_self_fix_bashrc () {
 _moonshell_self_fix_link () {
     local src=$1
     local dst=$2
-    ln -sv ${src} ${dst}
+    ln -sfhv ${src} ${dst}
 }
 
 _moonshell_self_fix_gems () {


### PR DESCRIPTION
Need -fh options to ln command to force overwrite of the existing symlink to the moonshell directory.