### PR TITLE
Route53 purge host

### DIFF
--- a/bin/route53-add-host
+++ b/bin/route53-add-host
@@ -19,26 +19,22 @@ if [[ -z ${HOSTED_ZONE_ID-} ]]; then
     exit 1
 fi
 
-echo -n "Record to add: "
-read RESOURCE
+read -p "Record to add: " RESOURCE
 [[ ! ${RESOURCE} =~ "${DOMAIN_NAME}" ]] \
     && echoerr "ERROR: The resource name to add must be suffixed with the domain name '${DOMAIN_NAME}'"\
     && exit 1
 
-echo -n "Type (CNAME|A): "
-read TYPE
+read -p "Type (CNAME|A): " TYPE
 [[ ! ${TYPE} =~ ^(A|CNAME)$ ]] \
     && echoerr "ERROR: Type must be either A or CNAME" \
     && exit 1
 
-echo -n "TTL (seconds): "
-read TTL
+read -p "TTL (seconds): " TTL
 [[ ! ${TTL} =~ ^[0-9]+$ ]] \
     && echoerr "ERROR: TTL must be numerid" \
     && exit 1
 
-echo -n "Target FQDN: "
-read TARGET
+read -p "Target FQDN: " TARGET
 
 RESOURCE_RECORD="{\"Name\":\"${RESOURCE}\",\"Type\":\"${TYPE}\",\"TTL\":${TTL},\"ResourceRecords\":[{\"Value\":\"${TARGET}\"}]}"
 

--- a/bin/route53-add-host
+++ b/bin/route53-add-host
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+#
+#
+
+source ${MOON_SHELL}
+
+[[ $# -lt 1 ]] \
+    && echoerr "Usage: $(basename $0) DOMAIN_NAME" \
+    && exit \
+    || DOMAIN_NAME=$1
+
+[[ ! ${DOMAIN_NAME} =~ \.$ ]] && DOMAIN_NAME="${DOMAIN_NAME}."
+
+HOSTED_ZONE_ID=$(route53_id_from_zone_name ${DOMAIN_NAME})
+
+if [[ -z ${HOSTED_ZONE_ID-} ]]; then
+    echoerr "ERROR: No Id found for domain '${DOMAIN_NAME}'"
+    exit 1
+fi
+
+echo -n "Record to add: "
+read RESOURCE
+[[ ! ${RESOURCE} =~ "${DOMAIN_NAME}" ]] \
+    && echoerr "ERROR: The resource name to add must be suffixed with the domain name '${DOMAIN_NAME}'"\
+    && exit 1
+
+echo -n "Type (CNAME|A): "
+read TYPE
+[[ ! ${TYPE} =~ ^(A|CNAME)$ ]] \
+    && echoerr "ERROR: Type must be either A or CNAME" \
+    && exit 1
+
+echo -n "TTL (seconds): "
+read TTL
+[[ ! ${TTL} =~ ^[0-9]+$ ]] \
+    && echoerr "ERROR: TTL must be numerid" \
+    && exit 1
+
+echo -n "Target FQDN: "
+read TARGET
+
+RESOURCE_RECORD="{\"Name\":\"${RESOURCE}\",\"Type\":\"${TYPE}\",\"TTL\":${TTL},\"ResourceRecords\":[{\"Value\":\"${TARGET}\"}]}"
+
+route53_change_resource_records ${HOSTED_ZONE_ID} UPSERT ${RESOURCE_RECORD}
+
+exit $?

--- a/bin/route53-purge-host
+++ b/bin/route53-purge-host
@@ -19,8 +19,7 @@ echo "Choose a host to purge:"
 RESOURCE_NAME=$(choose ${RESOURCE_NAMES[@]})
 RESOURCE_RECORD=$(route53_get_resource_record ${HOSTED_ZONE_ID} ${RESOURCE_NAME})
 
-echo -n "Are you sure you wish to permanently delete host '${RESOURCE_NAME}'? (y/N): "
-read choice
+read -p "Are you sure you wish to permanently delete host '${RESOURCE_NAME}'? (y/N): " -n 1 choice
 [[ ! ${choice} =~ ^[y|Y]$ ]] \
     && echoerr "INFO: Cancelled by user request" \
     && exit \

--- a/bin/route53-purge-host
+++ b/bin/route53-purge-host
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+#
+#
+
+source ${MOON_SHELL}
+
+[[ $# -lt 1 ]] \
+    && echoerr "Usage: $(basename $0) ENVIRONMENT" \
+    && exit \
+    || ENVIRONMENT=$1
+
+STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
+HOSTED_ZONE_ID=$(route53_internal_hosted_zone_id ${STACK_NAME})
+RESOURCE_NAMES=($(route53_list_type_records ${HOSTED_ZONE_ID} A \
+    && route53_list_type_records ${HOSTED_ZONE_ID} CNAME))
+
+echo "Choose a host to purge:"
+RESOURCE_NAME=$(choose ${RESOURCE_NAMES[@]})
+RESOURCE_RECORD=$(route53_get_resource_record ${HOSTED_ZONE_ID} ${RESOURCE_NAME})
+
+echo -n "Are you sure you wish to permanently delete host '${RESOURCE_NAME}'? (y/N): "
+read choice
+[[ ! ${choice} =~ ^[y|Y]$ ]] \
+    && echoerr "INFO: Cancelled by user request" \
+    && exit \
+
+route53_delete_record_set ${HOSTED_ZONE_ID} ${RESOURCE_RECORD}
+
+

--- a/lib/aws/bastion.sh
+++ b/lib/aws/bastion.sh
@@ -7,7 +7,7 @@ bastion () {
     local bastion_hostname="bastion-${AWS_ACCOUNT_NAME}"
     if [[ "$(grep ${bastion_hostname} ${HOME}/.ssh/config)" == "" ]]; then
         echoerr "ERROR: You do not have configuration set for ${bastion_hostname} in ~/.ssh/config"
-        exit 1
+        return 1
     else
         echo -n "${bastion_hostname}"
         return 0

--- a/lib/aws/route53.sh
+++ b/lib/aws/route53.sh
@@ -199,7 +199,7 @@ route53_list_type_records () {
     local hosted_zone_id=$1
     [[ ! ${2} =~ ^(A|CNAME)$ ]] \
         && echoerr "ERROR: Unsupported type '${2}'" \
-        && exit 1 \
+        && return 1 \
         || local type=$2
 
     aws route53 list-resource-record-sets \

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -13,7 +13,7 @@ bash_rc_file () {
         Darwin) echo ".bash_profile";;
         *)
             echoerr "ERROR: Unsupported system '${uname}'"
-            exit 1
+            return 1
         ;;
     esac
 }


### PR DESCRIPTION
This PR is two for the price of one. I figured that if I was going to make something to delete a single host from DNS that I might as well add a way of creating one. As we automate DNS it's almost guaranteed that at some point something is going to happen where records are removed from DNS. We need a way of adding them back.

Case in point for this is that in the recent upgrades I have been doing to all the things I have made the setting of DNS and such more programmatic. The upgrade required manual deletion of some records and creation of others; this is only a problem for currently live stacks, new stacks are fine.