### PR TITLE
Compatibility fixes for Darwin:

### DIFF
--- a/bin/ami-build
+++ b/bin/ami-build
@@ -24,7 +24,7 @@ source $(dirname $0)/../moon.sh
 
 PACKER_DIR="${MOON_VAR}/packer"
 PACKER_VER="1.0.4"
-PACKER_FILE="packer_${PACKER_VER}_linux_amd64.zip"
+PACKER_FILE="packer_${PACKER_VER}_$(uname -s | tr A-Z a-z)_amd64.zip"
 PACKER_BASE="https://releases.hashicorp.com/packer/${PACKER_VER}"
 PACKER_URL="${PACKER_BASE}/${PACKER_FILE}"
 PACKER_LOG=1
@@ -40,7 +40,7 @@ VERBOSE=
 
 # pipe delimited string of AMIs to build - CLASSES="foo|bar|baz"
 # foo.json, bar.json and baz.json must exist in the packer directory.
-CLASSES="$(find packer/ -name '*.json' -printf '%f\n' | sed 's/\.json//' | sort)"
+CLASSES="$(find packer/ -name '*.json' -exec basename -s .json '{}' \;)"
 
 BUILD_ROOT="${PWD}"
 
@@ -64,7 +64,7 @@ usage () {
 
 log () {
     local message="$@"
-    echo "$(date --iso-8601=seconds) ${message}" >> ${LOG}
+    echo "$(date +%Y-%m-%dT%H:%M:%S) ${message}" >> ${LOG}
     echoerr "${message}"
 }
 
@@ -95,10 +95,10 @@ pack () {
 
     local ami_id retr
 
-    log "INFO: Building AMI from ${class}.json at $(date --iso-8601=seconds). Outputting to '${log_file}'"
+    log "INFO: Building AMI from ${class}.json at $(date +%Y-%m-%dT%H:%M:%S). Outputting to '${log_file}'"
     if [[ ${PACKER_DEBUG-} ]]; then
         if [[ ${VERBOSE-} ]]; then
-            ${PACKER_DIR}/packer build -debug ${PACKER_ARGS-} packer/${class}.json 2>&1 >>${log_file}
+            ${PACKER_DIR}/packer build -debug ${PACKER_ARGS-} packer/${class}.json >>${log_file} 2>&1
             retr=$?
         else
             ${PACKER_DIR}/packer build -debug ${PACKER_ARGS-} packer/${class}.json | tee -a ${log_file}
@@ -108,13 +108,13 @@ pack () {
         ${PACKER_DIR}/packer build ${PACKER_ARGS-} packer/${class}.json 2>&1 | tee -a ${log_file}
         retr=${PIPESTATUS[0]}
     else
-        ${PACKER_DIR}/packer build ${PACKER_ARGS-} packer/${class}.json &>>${log_file}
+        ${PACKER_DIR}/packer build ${PACKER_ARGS-} packer/${class}.json >>${log_file} 2>&1
         retr=$?
     fi
 
     if [[ ${retr} == 0 ]]; then
-        log "INFO: Finished building AMI from ${class}.json at $(date --iso-8601=seconds)"
-        ami_id=$(grep -Po "ami-[0-9a-f]{8,17}" ${log_file} | tail -1)
+        log "INFO: Finished building AMI from ${class}.json at $(date +%Y-%m-%dT%H:%M:%S)"
+        ami_id=$(grep -Eo "ami-[0-9a-f]{8,17}" ${log_file} | tail -1)
         log "INFO: ${class} AMI: ${ami_id}"
     else
         log "ERROR: Build failed with status '${retr}'"

--- a/bin/rds-snapshot-create
+++ b/bin/rds-snapshot-create
@@ -14,7 +14,7 @@ source $(dirname $0)/../moon.sh
 #
 # Even though AWS use colons in their automated snapshots they do not permit
 # users to define a snapshot name with them..
-DEFAULT_SNAPSHOT_NAME="manual-$(date --iso-8601)-$(date +%H-%M)"
+DEFAULT_SNAPSHOT_NAME="manual-$(date +%Y-%m-%d-%H-%M)"
 
 if [[ $# -lt 1 ]]; then
     echoerr "Usage: $(basename $0) ENVIRONMENT [SNAPSHOT_NAME]"

--- a/lib/aws/route53.sh
+++ b/lib/aws/route53.sh
@@ -93,7 +93,7 @@ route53_external_hosted_zone_id () {
     local hosted_zone_id=$(aws route53 list-hosted-zones-by-name \
         --query "HostedZones[?Name=='${hosted_zone_name}'].Id" \
         --output text \
-        | grep -Po '(\w+)$')
+        | grep -Eo '(\w+)$')
 
     if [[ -z ${hosted_zone_id-} ]]; then
         echoerr "ERROR: could not find hosted_zone_id from ${hosted_zone_name}"


### PR DESCRIPTION
- Remove use of date --iso-8601 option, replace with equivalent(ish) format strings
- Replace bash v4 '&>>$file' usage with '>$file 2>&1'
- Use extended regex in grep commands instead of (unsupported) perl regex
- Replace use of -printf argument to find command
- Fix packer download URL to grab the binary for the correct OS based on output from uname