### PR TITLE
Create private dirs

### DIFF
--- a/bin/route53-purge-host
+++ b/bin/route53-purge-host
@@ -20,6 +20,7 @@ RESOURCE_NAME=$(choose ${RESOURCE_NAMES[@]})
 RESOURCE_RECORD=$(route53_get_resource_record ${HOSTED_ZONE_ID} ${RESOURCE_NAME})
 
 read -p "Are you sure you wish to permanently delete host '${RESOURCE_NAME}'? (y/N): " -n 1 choice
+echo
 [[ ! ${choice} =~ ^[y|Y]$ ]] \
     && echoerr "INFO: Cancelled by user request" \
     && exit \

--- a/etc/profile.d/private.sh
+++ b/etc/profile.d/private.sh
@@ -2,10 +2,12 @@
 # PRIVATE VARIABLE CHAINLOADING
 #
 # 'private' is a directory that is excluded from git. If you wish to use
-# private libraries, just create the directory, or symlink to a location
-# where you are tracking your senstive files.
+# private libraries you can create shell files in this location, or use
+# the more preferred overlay_dir.
 #
-if [[ -d "${MOON_PROFILE}/private" ]] || [[ -L "${MOON_PROFILE}/private" ]]; then
+if [[ -d "${MOON_PROFILE}/private" ]]; then
     _moonshell_source ${MOON_PROFILE}/private
+else
+    mkdir -p "${MOON_PROFILE}/private"
 fi
 

--- a/lib/private.sh
+++ b/lib/private.sh
@@ -2,10 +2,13 @@
 # PRIVATE FUNCTION CHAINLOADING
 #
 # 'private' is a directory that is excluded from git. If you wish to use
-# private libraries, just create the directory, or symlink to a location
-# where you are tracking your senstive files.
+# private libraries you can create shell files in this location, or use
+# the more preferred overlay_dir.
 #
-if [[ -d ${MOON_LIB}/private ]] || [[ -L "${MOON_LIB}/private" ]] ; then
+
+if [[ -d ${MOON_LIB}/private ]]; then
     _moonshell_source ${MOON_LIB}/private
+else
+    mkdir -p "${MOON_LIB}/private"
 fi
 


### PR DESCRIPTION
huh, a commit I'd forgotten about that fixes output formatting.. go me..

anywho, the private dir fix will, on first sourcing of lib/private.sh and etc/profile.d/private.sh create the private dir if it doesn't exist. This fixes a bug with overlay_dir_install failing if the dir doesn't exist.