### PR TITLE
ensure moon.sh does not overlay_dir /

### DIFF
--- a/moon.sh
+++ b/moon.sh
@@ -134,7 +134,9 @@ if [[ ! $(basename "x$0") =~ "bash"$ ]]; then
     _moonshell_source ${MOON_LIB}
     _moonshell_source ${MOON_COMPLETION}
 
-    # Auto-source the CWD
-    overlay_dir ${PWD}
+    # Auto-source the CWD, unless we are in /
+    # /etc/profile.d/*.sh can not be sourced with `set -u`
+    [[ ! $(realpath ${PWD}) =~ ^/$ ]] \
+        && overlay_dir ${PWD}
 fi
 


### PR DESCRIPTION
Well, this one bit my ass for a while.. I was running a script from a script and the CWD defaulted to `/`, so `moon.sh` tried to `source /etc/profile.d/*.sh` with `set -u` which resulted in luls:
```
[2018-02-19 05:03:41.479] [REDACTED][stderr]//etc/profile.d/256term.sh: line 9: COLORTERM: unbound variable
```