### PR TITLE
Remove dependence on ruby and handle failures

### DIFF
--- a/bin/aws-creds
+++ b/bin/aws-creds
@@ -14,7 +14,14 @@
 # Because we output everything to STDERR this script is safe to eval :D
 #
 
-require 'parseconfig'
+begin
+  require 'parseconfig'
+rescue LoadError => e
+  puts "#{e.class}: #{e.message}"
+  puts e.backtrace.join("\n")
+  puts "Have you executed 'bundle install'?"
+  exit 1
+end
 
 credentials = ParseConfig.new("#{ENV['HOME']}/.aws/credentials")
 config = ParseConfig.new("#{ENV['HOME']}/.aws/config")

--- a/lib/moonshell.sh
+++ b/lib/moonshell.sh
@@ -14,17 +14,6 @@ _moonshell () {
         || _moonshell_getopts ${options[@]}
 }
 
-_moonshell_check () {
-    local moonshell_dir=$1
-
-    [[ ! -f "${moonshell_dir}/Gemfile.lock" ]] \
-        && echoerr "ERROR: Gemfile.lock not present." \
-        && echoerr "INFO: Try executing 'bundle install' inside of ${moonshell_dir}" \
-        && return 1
-
-    return 0
-}
-
 _moonshell_getopts () {
     OPTIND=1
     local optspec=":hrst" OPTARG=($@)

--- a/moon.sh
+++ b/moon.sh
@@ -51,16 +51,6 @@ source ${MOON_LIB}/common.sh
 source ${MOON_LIB}/moonshell.sh
 source ${MOON_LIB}/overlay.sh
 
-_moonshell_check ${MOON_ROOT}
-
-if [[ $? -gt 0 ]]; then
-    echoerr "FATAL: _moonshell_check did not return 0. Aborting"
-    # Exiting from a function can nuke a terminal, so return instead.
-    [[ $(basename "x$0") =~ "bash"$ ]] \
-        && return 255 \
-        || exit 255
-fi
-
 
 #
 # PROFILES


### PR DESCRIPTION
Sample of what happens when bundle install has not been executed and this sole ruby tool is run.
```
$ aws-creds
LoadError: cannot load such file -- parseconfig
REDACTED/rubygems/core_ext/kernel_require.rb:55:in `require'
REDACTED/rubygems/core_ext/kernel_require.rb:55:in `require'
REDACTED/moonshell/bin/aws-creds:18:in `<main>'
Have you executed 'bundle install'?
```