### PR TITLE
reinstate Moonfile check. handle unset AWS_ACCOUNT_NAME

### DIFF
--- a/bin/puppet-module-update
+++ b/bin/puppet-module-update
@@ -6,10 +6,9 @@
 # Puppetfile in the puppet directory.
 #
 
-export MOON_FILE=false
-export AWS_ACCOUNT_NAME=false
+[[ -z ${AWS_ACCOUNT_NAME-} ]] && export AWS_ACCOUNT_NAME=false
 
-source $(dirname $0)/../moon.sh
+source ${MOON_SHELL}
 
 # We must be in the root of the repo else ../moon.sh would not have been sourced
 pushd "${PWD}/puppet" >/dev/null


### PR DESCRIPTION
Given the dependency of needing `./puppet` we must ensure we are in the root of the repo. `AWS_ACCOUNT_NAME` is not required for puppet modules to be downloaded.