### PR TITLE
bump packer version to 1.2.1

### DIFF
--- a/bin/ami-build
+++ b/bin/ami-build
@@ -23,7 +23,7 @@ export MOON_FILE=false
 source $(dirname $0)/../moon.sh
 
 PACKER_DIR="${MOON_VAR}/packer"
-PACKER_VER="1.0.4"
+PACKER_VER="1.2.1"
 PACKER_FILE="packer_${PACKER_VER}_$(uname -s | tr A-Z a-z)_amd64.zip"
 PACKER_BASE="https://releases.hashicorp.com/packer/${PACKER_VER}"
 PACKER_URL="${PACKER_BASE}/${PACKER_FILE}"


### PR DESCRIPTION
This update works for all of our immediate intents and purposes.