### PR TITLE
Fix an amazing bug in using s3 multipart when the destination is a directory

### DIFF
--- a/lib/aws/s3.sh
+++ b/lib/aws/s3.sh
@@ -256,8 +256,16 @@ s3_upload () {
     if [[ ${verb} = 'cp' ]]; then
         local filesize=$(stat -c '%s' ${source})
         if [[ ${filesize} -gt 5242880 ]]; then
-            s3_upload_multipart ${s3_bucket_name} ${source} ${destination} ${options}
-            return $?
+            # If ${destination} has a trailing slash we have to append the
+            # source file else the file is created as the containing directory..
+            # This is only a bug for multi-part uploads and is a flaw in AWS
+            if [[ ${destination} =~ /$ ]]; then
+                s3_upload_multipart ${s3_bucket_name} ${source} ${destination}$(basename ${source}) ${options}
+                return $?
+            else
+                s3_upload_multipart ${s3_bucket_name} ${source} ${destination} ${options}
+                return $?
+            fi
         fi
     fi
 


### PR DESCRIPTION
Note the null/nil/missing filename of the first file below. AFAICT the filename is effectively `domain-artifacts/`, so there is both a file and folder called `domain-artifacts/`, which seems like an hilarious bug in S3 being an HTTP filesystem and this is only a problem with multi-part uploads as there doesn't appear to be the same level of input sanitisation as exists with `cp` and `sync`.
```
$ aws s3 ls s3://REDACTED_BUCKET_NAME/domain-artifacts/
2018-03-19 14:03:14   10873191 
2018-02-19 16:28:30   10857756 REDACTED.tgz
```
To fix ^^ you have to `aws s3 rm` the REDACTED.tgz file and then `rm` the containing directory, which you shouldn't need to do... but, here we are...