### PR TITLE
Refactor MOON_VAR to be more user specific for when Moonshell is deployed to a system

### DIFF
--- a/etc/profile.d/private.sh
+++ b/etc/profile.d/private.sh
@@ -7,7 +7,7 @@
 #
 if [[ -d "${MOON_PROFILE}/private" ]]; then
     _moonshell_source ${MOON_PROFILE}/private
-else
-    mkdir -p "${MOON_PROFILE}/private" 2>/dev/null || true
+elif [[ -w ${MOON_PROFILE} ]]; then
+    mkdir -p "${MOON_PROFILE}/private" 2>/dev/null
 fi
 

--- a/lib/complete.sh
+++ b/lib/complete.sh
@@ -3,18 +3,14 @@
 # BASH COMPLETION FUNCTIONS
 #
 
+source ${MOON_LIB}/moonshell.sh
+
 export MOON_VAR_COMPLETE="${MOON_VAR}/complete"
 
-[[ ! -d "${MOON_VAR_COMPLETE}" ]] \
-    && mkdir -p "${MOON_VAR_COMPLETE}" 2>/dev/null \
-    || true
-
-# Load all dynamically generated completion files
-#
-if [[ -d "${MOON_VAR_COMPLETE}" ]]; then
-    for complete_file in $(find "${MOON_VAR_COMPLETE}" ${MOON_FIND_OPTS}); do
-        source ${complete_file}
-    done
+if [[ ! -d ${MOON_VAR_COMPLETE} ]] && [[ -w ${MOON_VAR} ]]; then
+    mkdir -p "${MOON_VAR_COMPLETE}" 2>/dev/null
+elif [[ -d ${MOON_VAR_COMPLETE} ]]; then
+    _moonshell_source ${MOON_VAR_COMPLETE}
 fi
 
 # Private Functions

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -9,18 +9,14 @@
 # date.
 #
 
+source ${MOON_LIB}/moonshell.sh
+
 export MOON_VAR_ENVIRONMENT="${MOON_VAR}/environment"
 
-[[ ! -d "${MOON_VAR_ENVIRONMENT}" ]] \
-    && mkdir -p "${MOON_VAR_ENVIRONMENT}" 2>/dev/null \
-    || true
-
-# Load all dynamically generated environment files
-#
-if [[ -d "${MOON_VAR_ENVIRONMENT}" ]]; then
-    for env_file in $(find ${MOON_VAR_ENVIRONMENT} ${MOON_FIND_OPTS}); do
-        source ${env_file}
-    done
+if [[ ! -d ${MOON_VAR_ENVIRONMENT} ]] && [[ -w ${MOON_VAR} ]]; then
+    mkdir -p "${MOON_VAR_ENVIRONMENT}" 2>/dev/null
+elif [[ -d ${MOON_VAR_ENVIRONMENT} ]]; then
+    _moonshell_source ${MOON_VAR_ENVIRONMENT}
 fi
 
 # Public Functions

--- a/lib/private.sh
+++ b/lib/private.sh
@@ -7,9 +7,11 @@
 # the more preferred overlay_dir.
 #
 
+source ${MOON_LIB}/moonshell.sh
+
 if [[ -d ${MOON_LIB}/private ]]; then
     _moonshell_source ${MOON_LIB}/private
-else
-    mkdir -p "${MOON_LIB}/private" 2>/dev/null || true
+elif [[ -w ${MOON_LIB} ]]; then
+    mkdir -p "${MOON_LIB}/private" 2>/dev/null
 fi
 

--- a/moon.sh
+++ b/moon.sh
@@ -28,7 +28,20 @@ export MOON_BIN="${MOON_ROOT}/bin"
 export MOON_ETC="${MOON_ROOT}/etc"
 export MOON_LIB="${MOON_ROOT}/lib"
 export MOON_USR="${MOON_ROOT}/usr"
-export MOON_VAR="${MOON_ROOT}/var"
+
+# Not all users on a system can write to their ${HOME}
+[[ -w ${HOME} ]] \
+    && export MOON_HOME="${HOME}/.moonshell" \
+    && mkdir -m 0700 -p ${MOON_HOME} \
+    || export MOON_HOME="${MOON_ROOT}"
+
+# MOON_VAR is used for persisting of ephemeral data such as state, completion
+# scripts, log and application output. It is primarily used by console users,
+# does not need to be writable by service users, but must be set and exist.
+export MOON_VAR="${MOON_HOME}/var"
+if [[ -w ${MOON_HOME} ]] && [[ ! -d ${MOON_VAR} ]]; then
+    mkdir ${MOON_VAR}
+fi
 
 export MOON_COMPLETION="${MOON_ETC}/completion.d"
 export MOON_PROFILE="${MOON_ETC}/profile.d"


### PR DESCRIPTION
the main part of this PR is to create `${HOME}/.moonshell` and use it for variable data.