### PR TITLE
Admin node hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,3 +262,36 @@ To view all available KMS keys for your account:
 aws kms list-aliases
 ```
 
+### Jump Host / Bastion
+
+Connecting directly to your application servers via SSH is plain madness, poor
+practice and a violation of several security frameworks. Use a jump host!
+
+Depending on the application you are hosting you may choose to have a dedicated
+and separated 'admin' node from where you can perform your needed admin
+functions; it's poor form to give your application nodes access to all the
+things if not strictly required. To this end Moonshell contains several
+'bastion' functions. These are to enable scripts to execute remotely for
+dumping/restoring of databases or what ever you may need.
+
+To make the most of this you either need to export a variable; this is
+prepended to the internal domain name of the stack:
+
+```
+export ADMIN_NODE_HOSTNAME=
+```
+
+Or, create a function that returns the FQDN of the admin node, for example:
+
+```
+ssh_target_hostname () {
+    local stack_name=$1
+
+    case ${stack_name} in
+        foo-*) echo "admin.${stack_name}.local" ;;
+        bar-dev) echo "admin.yolo-dev.local" ;;
+        *) echo "localhost" ;;
+    esac
+}
+```
+

--- a/lib/aws/rds.sh
+++ b/lib/aws/rds.sh
@@ -88,7 +88,7 @@ rds_mysql_dump_db () {
 
     echoerr "INFO: Dumping ${database} to ${out_file}"
 
-    bastion_exec_utility ${stack_name} \
+    bastion_exec_admin ${stack_name} \
         "'mysqldump ${mysql_opts} ${database} | gzip -c'" \
         ${out_file}
 
@@ -106,7 +106,7 @@ rds_mysql_list_dbs () {
     stack_name=$1
     instance=$2
 
-    bastion_exec_utility ${stack_name} \
+    bastion_exec_admin ${stack_name} \
         "'mysql -BNe \"SHOW DATABASES;\"'"
 }
 
@@ -122,18 +122,18 @@ rds_mysql_restore_db () {
     bastion_upload_file ${stack_name} ${in_file}
 
     echoerr "INFO: Recreating database: ${database}"
-    bastion_exec_utility ${stack_name} \
+    bastion_exec_admin ${stack_name} \
         "'mysql -e \"DROP DATABASE IF EXISTS ${database}; CREATE DATABASE ${database};\"'"
 
     echoerr "INFO: Restoring database from /tmp/${upload_file}"
-    bastion_exec_utility ${stack_name} \
+    bastion_exec_admin ${stack_name} \
         "'zcat /tmp/${upload_file} \
             | mysql ${mysql_opts} ${database}; \
             rm -f /tmp/${upload_file}'"
 
     echoerr "INFO: Removing uploaded files"
     bastion_exec "rm -f /tmp/${upload_file}"
-    bastion_exec_utility ${stack_name} "rm -f /tmp/${upload_file}"
+    bastion_exec_admin ${stack_name} "rm -f /tmp/${upload_file}"
 }
 
 rds_postgres_dump_all () {
@@ -160,7 +160,7 @@ rds_postgres_dump_db () {
 
     echoerr "INFO: Dumping ${database} to ${out_file}"
 
-    bastion_exec_utility ${stack_name} \
+    bastion_exec_admin ${stack_name} \
         "'pg_dump -Fp ${pg_opts} ${database}'" \
         ${out_file}
 
@@ -190,7 +190,7 @@ rds_postgres_grant () {
     local stack_name=$1
     local database=$2
     echoerr "INFO: Granting ownership of ${database} to postgres"
-    bastion_exec_utility ${stack_name} \
+    bastion_exec_admin ${stack_name} \
         "'psql -d ${database} -c \"
             GRANT ${database}_app TO postgres;
             GRANT ${database}_client TO postgres;
@@ -200,7 +200,7 @@ rds_postgres_grant () {
 rds_postgres_list_dbs () {
     local stack_name=$1
 
-    local databases=($(bastion_exec_utility ${stack_name} \
+    local databases=($(bastion_exec_admin ${stack_name} \
         "'psql -tAc \"select datname from pg_DATABASE;\"'"))
     [[ -z ${databases[@]-} ]] && return 1
 
@@ -236,14 +236,14 @@ rds_postgres_restore_db () {
     bastion_upload_file ${stack_name} ${in_file}
 
     echoerr "INFO: Restoring DB to ${database}:"
-    bastion_exec_utility ${stack_name} \
+    bastion_exec_admin ${stack_name} \
         "'zcat /tmp/${upload_file} | psql ${pg_opts} -d ${database}'"
 
     rds_postgres_revoke ${stack_name} ${database}
 
     echoerr "INFO: Removing uploaded files"
     bastion_exec "rm -f /tmp/${upload_file}"
-    bastion_exec_utility ${stack_name} "rm -f /tmp/${upload_file}"
+    bastion_exec_admin ${stack_name} "rm -f /tmp/${upload_file}"
 
     return $?
 }
@@ -253,7 +253,7 @@ rds_postgres_revoke () {
     local stack_name=$1
     local database=$2
     echoerr "INFO: Revoking ownership of ${database} from postgres"
-    bastion_exec_utility ${stack_name} \
+    bastion_exec_admin ${stack_name} \
         "'psql -d ${database} -c \"
             REVOKE ${database}_app FROM postgres;
             REVOKE ${database}_client FROM postgres;


### PR DESCRIPTION
I've wrestled with how to do execution of commands on a remote host for a while and feel this is finally supportable, simple and sensical. To make things even easier I even added to the README! wow, doco!

The setting and use of `ADMIN_NODE_HOSTNAME` needs to be variable as a stack may not always have a node called `app`, or `utility` etc and trying to figure that out programmatically is a trap, so let the user set it for their stack themselves.