### PR TITLE
elb-certificate-update: Output certificate details before setting to an ELB

### DIFF
--- a/bin/elb-certificate-update
+++ b/bin/elb-certificate-update
@@ -34,6 +34,15 @@ IAM_CERT_ARN="$(aws iam list-server-certificates \
     --output text)"
 echoerr "INFO: Certificate ARN: ${IAM_CERT_ARN}"
 
+echoerr "INFO: Outputting certificate details:"
+aws iam get-server-certificate \
+    --server-certificate-name ${IAM_CERT_NAME} \
+    --query "ServerCertificate.CertificateBody" \
+    --output text \
+    | openssl x509 -text -noout \
+    | \grep -E "Issuer:|Not Before|Not After|Subject:|DNS:" \
+    | sed -e 's/^ */  /g'
+
 echoerr "INFO: Selecting ELB to update"
 STACK_ELBS=($(stack_resource_type ${STACK_NAME} "AWS::ElasticLoadBalancing::LoadBalancer"))
 [[ ${#STACK_ELBS[@]} -gt 1 ]] \


### PR DESCRIPTION
Sanitised sample output
```
$ elb-certificate-update dev
INFO: Enumerating available server certificates
Choose a certificate to use:
  0: foo.example.com
  1: bar.example.com
Choice [0-1]: 1
INFO: Querying certificate ARN
INFO: Certificate ARN: arn:aws:iam::REDACTED:server-certificate/bar.example.com
INFO: Outputting certificate details
  Issuer: C = US, O = Let's Encrypt, CN = Let's Encrypt Authority X3
  Not Before: Mar 15 04:07:09 2018 GMT
  Not After : Jun 13 04:07:09 2018 GMT
  Subject: CN = bar.example.com
  DNS:*.bar.example.com, DNS:bar.example.com
INFO: Selecting ELB to update
Choose an ELB to update:
  0: bar-dev-APPE-asdfadsfasdf
  1: bar-dev-VARNI-asdfasdfasdf
Choice [0-1]: ^C
```