### PR TITLE
only remove comment on extension when restoring pg dump

### DIFF
--- a/lib/aws/rds.sh
+++ b/lib/aws/rds.sh
@@ -178,12 +178,7 @@ rds_postgres_dump_db () {
     echoerr "INFO: Dumping ${database} to ${out_file}"
 
     bastion_exec_admin ${stack_name} \
-        "pg_dump -Fp ${pg_opts} ${database} \
-            | sed \
-                -e '/^COMMENT ON EXTENSION plpgsql IS/d' \
-                -e '/^COMMENT ON EXTENSION citext IS/d' \
-                -e '/^COMMENT ON EXTENSION \"uuid-ossp\" IS/d' \
-            | gzip -c" \
+        "pg_dump -Fp ${pg_opts} ${database} | gzip -c" \
         ${out_file}
 
     rds_postgres_revoke ${stack_name} ${database}
@@ -253,7 +248,12 @@ rds_postgres_restore_db () {
 
     echoerr "INFO: Restoring DB to ${database}:"
     bastion_exec_admin ${stack_name} \
-        "zcat /tmp/${upload_file} | psql ${pg_opts} -d ${database}"
+        "zcat /tmp/${upload_file} \
+            | sed \
+                -e '/^COMMENT ON EXTENSION plpgsql IS/d' \
+                -e '/^COMMENT ON EXTENSION citext IS/d' \
+                -e '/^COMMENT ON EXTENSION \"uuid-ossp\" IS/d' \
+            | psql ${pg_opts} -d ${database}"
 
     rds_postgres_revoke ${stack_name} ${database}
 


### PR DESCRIPTION
Because it's best practice to dump a DB completely with no manipulation we move the AWS breaking shiz from dumping in to restoring only. Because superuser isn't in AWS land we have to strip out three comments which for some reason require super privileges which are not available.