### PR TITLE
add pipe_failure function to common.sh

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -91,3 +91,19 @@ matches () {
     return 1
 }
 
+pipe_failure () {
+    # Return true if a non-zero exit code was found
+    #
+    # if pipe_failure ${PIPESTATUS[@]}; then handle_error; fi
+    local -a pipestatus=($@)
+    local status
+
+    for status in ${pipestatus[@]}; do
+        if [[ ${status} -ne 0 ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+


### PR DESCRIPTION
This handy function can be used to quickly evaluate `PIPESTATUS` and enable you to handle non-zero exits

example usage:
```
if pipe_failure ${PIPESTATUS[@]}; then
    echoerr "ERROR: Piped process exited non-zero"
    exit 1
fi
```