### PR TITLE
Sg tools

### DIFF
--- a/bin/autoscaling-capacity
+++ b/bin/autoscaling-capacity
@@ -21,7 +21,7 @@ fi
 STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
 
 echoerr "INFO: Finding all ASGs for stack '${STACK_NAME}'"
-AUTO_SCALING_GROUPS=($(stack_resource_type ${STACK_NAME} "AWS::AutoScaling::AutoScalingGroup"))
+AUTO_SCALING_GROUPS=($(stack_resource_type_id ${STACK_NAME} "AWS::AutoScaling::AutoScalingGroup"))
 
 echoerr "Choose an ASG to modify:"
 AUTO_SCALING_GROUP=$(choose ${AUTO_SCALING_GROUPS[@]})

--- a/bin/elb-certificate-update
+++ b/bin/elb-certificate-update
@@ -38,7 +38,7 @@ IAM_CERT_ARN="$(aws iam list-server-certificates \
 echoerr "INFO: Certificate ARN: ${IAM_CERT_ARN}"
 
 echoerr "INFO: Selecting ELB to update"
-STACK_ELBS=($(stack_resource_type ${STACK_NAME} "AWS::ElasticLoadBalancing::LoadBalancer"))
+STACK_ELBS=($(stack_resource_type_id ${STACK_NAME} "AWS::ElasticLoadBalancing::LoadBalancer"))
 HTTPS_ELBS=($(aws elb describe-load-balancers \
     --region ${AWS_REGION} \
     --load-balancer-names ${STACK_ELBS[@]} \

--- a/bin/sg-group-list
+++ b/bin/sg-group-list
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+#
+#
+
+source $(dirname $0)/../moon.sh
+
+if [[ $# -lt 1 ]]; then
+    echoerr "Usage: $(basename $0) ENVIRONMENT"
+    exit 0
+else
+    ENVIRONMENT=$1
+fi
+
+export STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
+
+echoerr "INFO: Finding all security group names in '${STACK_NAME}'"
+SECURITY_GROUPS=($(sg_group_list ${STACK_NAME}))
+
+for security_group in ${SECURITY_GROUPS[@]}; do
+    echo ${security_group}
+done
+

--- a/bin/sg-rule-add-egress
+++ b/bin/sg-rule-add-egress
@@ -1,0 +1,1 @@
+sg-rule-add-ingress

--- a/bin/sg-rule-add-ingress
+++ b/bin/sg-rule-add-ingress
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 #
-# Create a new ingress or egress rule.
+# Add or delete an ingress or egress rule.
 #
-# We do not support specifying a source-security-group-id, as that is something
-# which should be done via a template modification and adds too much complexity
-# to this simple little script.
+# We do not support specifying a source or destination security-group-id, as
+# that is something which should be done via a template modification.
 #
 
 source $(dirname $0)/../moon.sh
 
 BASENAME=$(basename $0)
+case ${BASENAME%-*} in
+    *-add) ACTION=authorize;;
+    *-delete) ACTION=revoke;;
+    *)
+        echoerr "FATAL: Unsupported usage"
+        exit 255
+    ;;
+esac
+DIRECTION=${BASENAME##*-}
 
 if [[ $# -lt 5 ]]; then
     echoerr "Usage: ${BASENAME} ENVIRONMENT SG_NAME|SG_ID PROTOCOL PORT CIDR"
@@ -66,10 +74,8 @@ fi
 
 echo "${SG_ID} ${PROTOCOL} ${PORT} ${CIDR}"
 
-DIRECTION=${BASENAME##*-}
-
-echoerr "INFO: Creating ${DIRECTION} rule in '${SG_ID}'"
-aws ec2 authorize-security-group-${DIRECTION} \
+echoerr "INFO: Modifying ${DIRECTION} rule in '${SG_ID}'"
+aws ec2 ${ACTION}-security-group-${DIRECTION} \
     --region ${AWS_REGION} \
     --group-id ${SG_ID} \
     --port ${PORT} \

--- a/bin/sg-rule-add-ingress
+++ b/bin/sg-rule-add-ingress
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Create a new ingress or egress rule.
+#
+# We do not support specifying a source-security-group-id, as that is something
+# which should be done via a template modification and adds too much complexity
+# to this simple little script.
+#
+
+source $(dirname $0)/../moon.sh
+
+BASENAME=$(basename $0)
+
+if [[ $# -lt 5 ]]; then
+    echoerr "Usage: ${BASENAME} ENVIRONMENT SG_NAME|SG_ID PROTOCOL PORT CIDR"
+    echoerr
+    echoerr "Example:"
+    echoerr "  $ ${BASENAME} dev MySecurityGroup tcp 443 10.1.2.0/24"
+    echoerr "  $ ${BASENAME} staging AnotherSecurityGroup icmp -1 54.123.54.123/32"
+    echoerr "  $ ${BASENAME} production YetAnotherSecurityGroup udp 1-65535 10.0.0.0/8"
+    exit 0
+else
+    ENVIRONMENT=$1
+    SG=$2
+    PROTOCOL=$3
+    PORT=$4
+    CIDR=$5
+fi
+
+export STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
+
+
+#
+# Input Sanitisation
+#
+if [[ ! ${SG} =~ ^sg- ]]; then
+    SG_ID=$(stack_resource_id ${STACK_NAME} ${SG})
+else
+    SG_ID=${SG}
+fi
+
+if ! contains ${PROTOCOL} icmp tcp udp; then
+    echoerr "ERROR: Unsupported protocol '${PROTOCOL}'"
+    exit 1
+fi
+
+
+if [[ ! ${PORT} == -1 ]]; then
+    # Support port ranges '1-65535'
+    ports=(${PORT%-*} ${PORT#*-})
+    for port in ${ports[@]}; do
+        if [[ ${port} -lt 1 ]] || [[ ${port} -gt 65535 ]]; then
+            echoerr "ERROR: Unsupported port '${port}'"
+            exit 1
+        fi
+    done
+fi
+
+OCTET="([0-9]|[0-9]{2}|1[0-9]{2}|2([0-4][0-9]|5[0-5]))"
+VLSM="([0-9]|[1-2][0-9]|3[0-2])"
+
+if ! echo ${CIDR} | grep -qP "${OCTET}\.${OCTET}\.${OCTET}\.${OCTET}\/${VLSM}$"; then
+    echoerr "ERROR: Unsupported CIDR notation '${CIDR}'"
+    exit 1
+fi
+
+echo "${SG_ID} ${PROTOCOL} ${PORT} ${CIDR}"
+
+DIRECTION=${BASENAME##*-}
+
+echoerr "INFO: Creating ${DIRECTION} rule in '${SG_ID}'"
+aws ec2 authorize-security-group-${DIRECTION} \
+    --region ${AWS_REGION} \
+    --group-id ${SG_ID} \
+    --port ${PORT} \
+    --protocol ${PROTOCOL} \
+    --cidr ${CIDR}
+

--- a/bin/sg-rule-add-ingress
+++ b/bin/sg-rule-add-ingress
@@ -23,9 +23,9 @@ if [[ $# -lt 5 ]]; then
     echoerr "Usage: ${BASENAME} ENVIRONMENT SG_NAME|SG_ID PROTOCOL PORT CIDR"
     echoerr
     echoerr "Example:"
-    echoerr "  $ ${BASENAME} dev MySecurityGroup tcp 443 10.1.2.0/24"
+    echoerr "  $ ${BASENAME} production MyOGSecurityGroup tcp 443 10.1.2.0/24"
     echoerr "  $ ${BASENAME} staging AnotherSecurityGroup icmp -1 54.123.54.123/32"
-    echoerr "  $ ${BASENAME} production YetAnotherSecurityGroup udp 1-65535 10.0.0.0/8"
+    echoerr "  $ ${BASENAME} dev BoomAnotherSecurityGroup udp 1-65535 10.0.0.0/8"
     exit 0
 else
     ENVIRONMENT=$1
@@ -72,6 +72,10 @@ if ! echo ${CIDR} | grep -qP "${OCTET}\.${OCTET}\.${OCTET}\.${OCTET}\/${VLSM}$";
     exit 1
 fi
 
+
+#
+# Main
+#
 echoerr "INFO: Modifying ${DIRECTION} rule in '${SG_ID}'"
 aws ec2 ${ACTION}-security-group-${DIRECTION} \
     --region ${AWS_REGION} \

--- a/bin/sg-rule-add-ingress
+++ b/bin/sg-rule-add-ingress
@@ -72,8 +72,6 @@ if ! echo ${CIDR} | grep -qP "${OCTET}\.${OCTET}\.${OCTET}\.${OCTET}\/${VLSM}$";
     exit 1
 fi
 
-echo "${SG_ID} ${PROTOCOL} ${PORT} ${CIDR}"
-
 echoerr "INFO: Modifying ${DIRECTION} rule in '${SG_ID}'"
 aws ec2 ${ACTION}-security-group-${DIRECTION} \
     --region ${AWS_REGION} \

--- a/bin/sg-rule-delete-egress
+++ b/bin/sg-rule-delete-egress
@@ -1,0 +1,1 @@
+sg-rule-add-ingress

--- a/bin/sg-rule-delete-ingress
+++ b/bin/sg-rule-delete-ingress
@@ -1,0 +1,1 @@
+sg-rule-add-ingress

--- a/bin/sg-rule-list-egress
+++ b/bin/sg-rule-list-egress
@@ -1,0 +1,1 @@
+sg-rule-list-ingress

--- a/bin/sg-rule-list-ingress
+++ b/bin/sg-rule-list-ingress
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+#
+#
+
+source $(dirname $0)/../moon.sh
+
+BASENAME=$(basename $0)
+
+if [[ $# -lt 2 ]]; then
+    echoerr "Usage: ${BASENAME} ENVIRONMENT SG_NAME|SG_ID"
+    exit 0
+else
+    ENVIRONMENT=$1
+    SG=$2
+fi
+
+export STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
+
+if [[ ${SG} =~ ^sg- ]]; then
+    SG_ID=${SG}
+else
+    SG_ID=$(stack_resource_id ${STACK_NAME} ${SG})
+fi
+
+SG_OUTPUT="$(aws ec2 describe-security-groups \
+    --region ${AWS_REGION} \
+    --group-ids ${SG_ID})"
+
+DIRECTION=${BASENAME##*-}
+
+case ${DIRECTION} in
+    ingress) PERMISSIONS="IpPermissions" ;;
+    egress) PERMISSIONS="IpPermissionsEgress" ;;
+    *)
+        echoerr "FATAL: Unsupported method '${DIRECTION}'"
+        exit 255
+    ;;
+esac
+
+echoerr "INFO: Listing ${DIRECTION} rules for security group '${SG_ID}'"
+echo ${SG_OUTPUT} \
+    | jq "[.SecurityGroups[].${PERMISSIONS}[] | {\"FromPort\": .FromPort, \"ToPort\": .ToPort, \"IpProtocol\": .IpProtocol, \"IpRanges\": .IpRanges, \"UserIdGroupPairs\": .UserIdGroupPairs} ]"
+

--- a/bin/vpc-associate
+++ b/bin/vpc-associate
@@ -53,12 +53,12 @@ if [[ -z ${TARGET_STACK_NAME-} ]]; then
 fi
 
 echoerr "INFO: Setting ${SELF_STACK_NAME} variables"
-SELF_VPC_ID=$(stack_resource_type ${SELF_STACK_NAME} "AWS::EC2::VPC")
+SELF_VPC_ID=$(stack_resource_type_id ${SELF_STACK_NAME} "AWS::EC2::VPC")
 SELF_VPC_NETWORK=$(stack_value_parameter ${SELF_STACK_NAME} VPCNetwork)
 SELF_VPC_ROUTE_TABLE=$(stack_value_output ${SELF_STACK_NAME} RouteTableId)
 
 echoerr "INFO: Setting ${TARGET_STACK_NAME} variables"
-TARGET_VPC_ID=$(stack_resource_type ${TARGET_STACK_NAME} "AWS::EC2::VPC")
+TARGET_VPC_ID=$(stack_resource_type_id ${TARGET_STACK_NAME} "AWS::EC2::VPC")
 TARGET_VPC_NETWORK=$(stack_value_parameter ${TARGET_STACK_NAME} VPCNetwork)
 TARGET_VPC_ROUTE_TABLE=$(stack_value_output ${TARGET_STACK_NAME} RouteTableId)
 

--- a/bin/vpc-dissociate
+++ b/bin/vpc-dissociate
@@ -54,7 +54,7 @@ PEERING_STATUS_CODES=(\
 # MAIN
 #
 echoerr "INFO: Setting ${SELF_STACK_NAME} variables"
-SELF_VPC_ID=$(stack_resource_type ${SELF_STACK_NAME} "AWS::EC2::VPC")
+SELF_VPC_ID=$(stack_resource_type_id ${SELF_STACK_NAME} "AWS::EC2::VPC")
 SELF_VPC_NETWORK=$(stack_value_parameter ${SELF_STACK_NAME} VPCNetwork)
 SELF_VPC_ROUTE_TABLE=$(stack_value_output ${SELF_STACK_NAME} RouteTableId)
 

--- a/lib/aws/rds.sh
+++ b/lib/aws/rds.sh
@@ -405,7 +405,7 @@ rds_stack_resources () {
 
         for nested_stack in ${stack_name} ${nested_stacks[@]}; do
             # squelch 'warning' output from testing a stack that does not have a DBInstance
-            db_instance_test=($(stack_resource_type ${nested_stack} "AWS::RDS::DBInstance" 2>/dev/null))
+            db_instance_test=($(stack_resource_type_id ${nested_stack} "AWS::RDS::DBInstance" 2>/dev/null))
             if [[ ${#db_instance_test[@]} -gt 0 ]]; then
                 echo ${db_instance_test[@]}
                 return 0
@@ -413,7 +413,7 @@ rds_stack_resources () {
         done
         return 1
     else
-        stack_resource_type ${stack_name} "AWS::RDS::DBInstance"
+        stack_resource_type_id ${stack_name} "AWS::RDS::DBInstance"
         return $?
     fi
 }

--- a/lib/aws/s3.sh
+++ b/lib/aws/s3.sh
@@ -288,7 +288,7 @@ s3_stack_bucket_name () {
         return 0
     fi
 
-    local -a s3_buckets=($(stack_resource_type ${stack_name} "AWS::S3::Bucket"))
+    local -a s3_buckets=($(stack_resource_type_id ${stack_name} "AWS::S3::Bucket"))
 
     if [[ -z ${s3_buckets[@]-} ]]; then
         echoerr "ERROR: No S3 buckets found in stack '${stack_name}'"

--- a/lib/aws/sg.sh
+++ b/lib/aws/sg.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+#
+#
+
+sg_group_list () {
+    local stack_name=$1
+
+    stack_resource_type_name ${stack_name} "AWS::EC2::SecurityGroup"
+}

--- a/lib/aws/stack.sh
+++ b/lib/aws/stack.sh
@@ -97,6 +97,8 @@ stack_resource_type_id () {
         return 0
     fi
 }
+# TODO: Remove this once all the things have been updated to not need it.
+alias stack_resource_type=stack_resource_type_id
 
 stack_resource_type_name () {
     # Return an array of resource names of type ${resource_type}.

--- a/lib/aws/stack.sh
+++ b/lib/aws/stack.sh
@@ -79,15 +79,34 @@ stack_resource_id () {
 }
 
 stack_resource_type_id () {
-    # Return an array of resource_ids of type ${resource_type}. This is handy for
-    # if a stack has multiple AWS::S3::Buckets or AWS::RDS::DBInstances.
+    # Return an array of resource ids of type ${resource_type}.
+    local stack_name=$1
+    local resource_type=$2
+
+    local -a resource_ids=($(aws cloudformation list-stack-resources \
+        --region ${AWS_REGION} \
+        --stack-name "${stack_name}" \
+        --query "StackResourceSummaries[?ResourceType=='${resource_type}'].PhysicalResourceId" \
+        --output text))
+
+    if [[ -z ${resource_ids[@]-} ]]; then
+        echoerr "WARNING: No resources of type ${resource_type} found"
+        return 1
+    else
+        echo ${resource_ids[@]}
+        return 0
+    fi
+}
+
+stack_resource_type_name () {
+    # Return an array of resource names of type ${resource_type}.
     local stack_name=$1
     local resource_type=$2
 
     local -a resource_names=($(aws cloudformation list-stack-resources \
         --region ${AWS_REGION} \
         --stack-name "${stack_name}" \
-        --query "StackResourceSummaries[?ResourceType=='${resource_type}'].PhysicalResourceId" \
+        --query "StackResourceSummaries[?ResourceType=='${resource_type}'].LogicalResourceId" \
         --output text))
 
     if [[ -z ${resource_names[@]-} ]]; then

--- a/lib/aws/stack.sh
+++ b/lib/aws/stack.sh
@@ -78,7 +78,7 @@ stack_resource_id () {
     fi
 }
 
-stack_resource_type () {
+stack_resource_type_id () {
     # Return an array of resource_ids of type ${resource_type}. This is handy for
     # if a stack has multiple AWS::S3::Buckets or AWS::RDS::DBInstances.
     local stack_name=$1

--- a/lib/aws/vpc.sh
+++ b/lib/aws/vpc.sh
@@ -6,7 +6,7 @@ vpc_id_from_stack_name () {
     # Find the VPCId for ${stack_name}
     local stack_name=$1
 
-    stack_resource_type ${stack_name} "AWS::EC2::VPC"
+    stack_resource_type_id ${stack_name} "AWS::EC2::VPC"
     return $?
 }
 


### PR DESCRIPTION
This PR includes addition of secgroup modification tools and a minor update to getting resource names and ids from a stack.

We currently only support adding/removing rules to/from ingress/egress chains of a security group. Meaning that we don't support SG ID based rules. This decision was made to simplify scripts and get around potential issues caused by SG IDs changing with stack updates. If you wish to make a rule which uses an SG ID, then to it in your template where you can variablise all the things, it's safer and IMO better practice.

Kudos AWS for making their authorise/revoke ingress/egress tools consistent.