### PR TITLE
s3_path_sanitise

### DIFF
--- a/bin/s3-cp
+++ b/bin/s3-cp
@@ -10,13 +10,14 @@ if [[ $# -lt 3 ]]; then
     exit 0
 else
     ENVIRONMENT=$1
-    STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
-    SOURCE=$2
-    DESTINATION=$3
+    SOURCE="$2"
+    DESTINATION="$3"
     shift 3
     OPTIONS=$*
 fi
 
-s3_cp ${STACK_NAME} ${SOURCE} ${DESTINATION} ${OPTIONS-}
+STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
+
+s3_cp ${STACK_NAME} "${SOURCE}" "${DESTINATION}" ${OPTIONS-}
 
 echoerr "INFO: Complete"

--- a/bin/s3-download
+++ b/bin/s3-download
@@ -12,22 +12,23 @@ if [[ $# -lt 3 ]]; then
     exit 0
 else
     ENVIRONMENT=$1
-    STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
     SOURCE=$2
     DESTINATION=$3
     shift 3
     OPTIONS=$*
 fi
 
+STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
+
 case $EXE in
     s3-download)
-        s3_download ${STACK_NAME} ${SOURCE} ${DESTINATION} ${OPTIONS-}
+        s3_download ${STACK_NAME} "${SOURCE}" "${DESTINATION}" ${OPTIONS-}
     ;;
     s3-upload)
-        s3_upload ${STACK_NAME} ${SOURCE} ${DESTINATION} ${OPTIONS-}
+        s3_upload ${STACK_NAME} "${SOURCE}" "${DESTINATION}" ${OPTIONS-}
     ;;
     s3-upload-multipart)
-        s3_upload_multipart ${STACK_NAME} ${SOURCE} ${DESTINATION} ${OPTIONS-}
+        s3_upload_multipart ${STACK_NAME} "${SOURCE}" "${DESTINATION}" ${OPTIONS-}
     ;;
     *)
         echoerr "ERROR: Unknown option '${EXE}'"

--- a/bin/s3-edit
+++ b/bin/s3-edit
@@ -14,7 +14,7 @@ if [[ $# -lt 2 ]]; then
 else
     ENVIRONMENT=$1
     # Strip any / prefix
-    FILE_PATH=${2#/}
+    FILE_PATH="$(s3_path_sanitise ${2})"
 fi
 
 STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
@@ -33,10 +33,10 @@ DST_FILE=$(mktemp)
 # Override the default to exit on non-zero. A file a person wishes to edit may
 # not exist yet
 set +e
-s3_download ${STACK_NAME} ${FILE_PATH} ${SRC_FILE} &>/dev/null
+s3_download ${STACK_NAME} "${FILE_PATH}" "${SRC_FILE}" &>/dev/null
 set -e
 
-cp ${SRC_FILE} ${DST_FILE}
+cp "${SRC_FILE}" "${DST_FILE}"
 
 while true; do
     echoerr "INFO: Editing '${DST_FILE}' with '${EDITOR}'"

--- a/bin/s3-ls
+++ b/bin/s3-ls
@@ -11,14 +11,9 @@ if [[ $# -lt 1 ]]; then
 else
     ENVIRONMENT=$1
     STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
-    if [[ ${2-} ]]; then
-        LOCATION=$2
-        if [[ ${LOCATION} =~ ^/ ]]; then
-            LOCATION="$(echo ${LOCATION} | sed -e 's/^\///g')"
-        fi
-    fi
+    LOCATION="${2-}"
 fi
 
-s3_ls ${STACK_NAME} ${LOCATION-}
+s3_ls ${STACK_NAME} "${LOCATION-}"
 
 echoerr "INFO: Complete"

--- a/bin/s3-mv
+++ b/bin/s3-mv
@@ -10,13 +10,14 @@ if [[ $# -lt 3 ]]; then
     exit 0
 else
     ENVIRONMENT=$1
-    STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
     SOURCE=$2
     DESTINATION=$3
     shift 3
     OPTIONS=$*
 fi
 
-s3_mv ${STACK_NAME} ${SOURCE} ${DESTINATION} ${OPTIONS-}
+STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
+
+s3_mv ${STACK_NAME} "${SOURCE}" "${DESTINATION}" ${OPTIONS-}
 
 echoerr "INFO: Complete"

--- a/bin/s3-rm
+++ b/bin/s3-rm
@@ -10,12 +10,13 @@ if [[ $# -lt 2 ]]; then
     exit 0
 else
     ENVIRONMENT=$1
-    STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
     FILE_PATH=$2
     shift 2
     OPTIONS=($*)
 fi
 
-s3_rm ${STACK_NAME} ${FILE_PATH} ${OPTIONS[@]-}
+STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
+
+s3_rm ${STACK_NAME} "${FILE_PATH}" ${OPTIONS[@]-}
 
 echoerr "INFO: Complete"


### PR DESCRIPTION
This should fix two issues:

1. We must ensure that any user specified path in s3 does not contain a `/` prefix because you can create directories which are tricky to identify and delete.
1. We must quote all paths in case the user provides a path with spaces in it. We do not need to %20 encode spaces, but we do need to treat paths with spaces as single strings.