### PR TITLE
remove unnecessary wait time when deleting certs

### DIFF
--- a/bin/iam-certificate-delete
+++ b/bin/iam-certificate-delete
@@ -36,9 +36,6 @@ echo
     && echoerr "ERROR: Aborting on user request" \
     && exit 1
 
-echoerr "INFO: Permanently deleting '${IAM_CERT_NAME}' in 7 seconds (Ctrl-C to cancel)"
-sleep 7
-
 aws iam delete-server-certificate \
     --region ${AWS_REGION} \
     --server-certificate-name ${IAM_CERT_NAME}


### PR DESCRIPTION
if a cert is in use the delete fails.