### PR TITLE
use a relative path for sourcing of moon.sh to avoid env issues

### DIFF
--- a/bin/autoscaling-capacity
+++ b/bin/autoscaling-capacity
@@ -8,7 +8,7 @@
 # script lets you easily set it back to 1 for retrying.
 #
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# -lt 1 ]]; then
     echoerr "Usage: $(basename $0) ENVIRONMENT [DESIRED_CAPACITY]"

--- a/bin/codedeploy-config-get
+++ b/bin/codedeploy-config-get
@@ -3,7 +3,7 @@
 #
 #
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# -lt 1 ]]; then
     echoerr "Usage: $(basename $0) ENVIRONMENT"

--- a/bin/codedeploy-config-set
+++ b/bin/codedeploy-config-set
@@ -3,7 +3,7 @@
 #
 #
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# -lt 1 ]]; then
     echoerr "Usage: $(basename $0) ENVIRONMENT [NEW_DEPLOYMENT_CONFIG]"

--- a/bin/elb-certificate-update
+++ b/bin/elb-certificate-update
@@ -3,7 +3,7 @@
 # This script sets an ELB with a previously uploaded server certificate
 #
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# -lt 1 ]]; then
     echoerr "Usage: $(basename $0) ENVIRONMENT"

--- a/bin/iam-certificate-delete
+++ b/bin/iam-certificate-delete
@@ -5,7 +5,7 @@
 
 export MOON_FILE=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# -gt 0 ]]; then
     IAM_CERT_NAME=$1

--- a/bin/iam-certificate-details
+++ b/bin/iam-certificate-details
@@ -5,7 +5,7 @@
 
 export MOON_FILE=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# == 0 ]]; then
     echoerr "Usage: $(basename $0) IAM_CERT_NAME"

--- a/bin/iam-certificate-update
+++ b/bin/iam-certificate-update
@@ -6,7 +6,7 @@
 
 export MOON_FILE=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# -lt 2 ]]; then
     echoerr "Usage: $(basename $0) CERT_FILE KEY_FILE [CA_FILE]"

--- a/bin/kms-get-policy
+++ b/bin/kms-get-policy
@@ -6,7 +6,7 @@
 
 export MOON_FILE=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# == 0 ]]; then
     echoerr "INFO: Finding custom key aliases"

--- a/bin/kms-key-detail
+++ b/bin/kms-key-detail
@@ -5,7 +5,7 @@
 
 export MOON_FILE=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# -lt 1 ]]; then
     echoerr "Usage: $(basename $0) KEY_ID|KEY_ALIAS"

--- a/bin/kms-list-grants
+++ b/bin/kms-list-grants
@@ -6,7 +6,7 @@
 
 export MOON_FILE=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# -lt 1 ]]; then
     echoerr "Usage: $(basename $0) KEY_ID|KEY_ALIAS [USER_GRANTEE]"

--- a/bin/kms-user-grant
+++ b/bin/kms-user-grant
@@ -12,7 +12,7 @@
 
 export MOON_FILE=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 GRANTS="Decrypt Encrypt ReEncryptFrom ReEncryptTo DescribeKey GenerateDataKey GenerateDataKeyWithoutPlaintext"
 

--- a/bin/kms-user-revoke
+++ b/bin/kms-user-revoke
@@ -5,7 +5,7 @@
 
 export MOON_FILE=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# -lt 1 ]]; then
     echoerr "Usage: $(basename $0) GRANTEE [KEY_ID|KEY_ALIAS]"

--- a/bin/letsencrypt-create-multidomain
+++ b/bin/letsencrypt-create-multidomain
@@ -5,7 +5,7 @@
 
 export MOON_FILE=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# -lt 1 ]]; then
     echoerr "Usage: $(basename $0) DOMAIN_NAME [DOMAIN_NAME]"

--- a/bin/letsencrypt-create-wildcard
+++ b/bin/letsencrypt-create-wildcard
@@ -5,7 +5,7 @@
 
 export MOON_FILE=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# -lt 1 ]]; then
     echoerr "Usage: $(basename $0) DOMAIN_SUFFIX [ACME_ARGS]"

--- a/bin/puppet-module-update
+++ b/bin/puppet-module-update
@@ -8,7 +8,7 @@
 
 [[ -z ${AWS_ACCOUNT_NAME-} ]] && export AWS_ACCOUNT_NAME=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 LOCK_FILE=${MOON_VAR}/r10k.lock
 

--- a/bin/route53-add-host
+++ b/bin/route53-add-host
@@ -5,7 +5,7 @@
 
 export MOON_FILE=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# -lt 1 ]]; then
     echoerr "Usage: $(basename $0) DOMAIN [OPTIONS]"

--- a/bin/route53-dump
+++ b/bin/route53-dump
@@ -6,7 +6,7 @@
 
 export MOON_FILE=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 # To provide a more informative 'Usage' messgage we first find all available
 # hosted zones

--- a/bin/route53-ls
+++ b/bin/route53-ls
@@ -6,7 +6,7 @@
 
 export MOON_FILE=false
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 ACC_ID=$(sts_account_id)
 

--- a/bin/route53-purge-host
+++ b/bin/route53-purge-host
@@ -3,7 +3,7 @@
 #
 #
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 [[ $# -lt 1 ]] \
     && echoerr "Usage: $(basename $0) ENVIRONMENT" \

--- a/bin/s3-get-version
+++ b/bin/s3-get-version
@@ -3,7 +3,7 @@
 # Downloads a specific version of a file stored in a stack's s3 bucket
 #
 
-source ${MOON_SHELL}
+source $(dirname $0)/../moon.sh
 
 if [[ $# -lt 3 ]]; then
     echoerr "Usage: $(basename $0) ENVIRONMENT S3_FILE DEST_FILE|DEST_PATH"

--- a/bin/stack-parameter-get
+++ b/bin/stack-parameter-get
@@ -3,9 +3,7 @@
 #
 #
 
-source ${MOON_SHELL}
-
-overlay_dir "$(dirname $0)/../"
+source $(dirname $0)/../moon.sh
 
 BASENAME=$(basename $0)
 

--- a/bin/stack-parameter-set
+++ b/bin/stack-parameter-set
@@ -7,9 +7,7 @@
 # used.
 #
 
-source ${MOON_SHELL}
-
-overlay_self
+source $(dirname $0)/../moon.sh
 
 BASENAME=$(basename $0)
 


### PR DESCRIPTION
Currently if `MOON_SHELL` is not set, or set incorrectly, then scripts inside this repo won't work, which seems kind of silly. This fix means that these scripts will always run relative to the repo they reside in which will (should) help with any future backwards compatibility breaking changes.