### PR TITLE
Elbv2

### DIFF
--- a/bin/elb-certificate-update
+++ b/bin/elb-certificate-update
@@ -45,24 +45,67 @@ IAM_CERT_ARN="$(aws iam list-server-certificates \
     --output text)"
 echoerr "INFO: Certificate ARN: ${IAM_CERT_ARN}"
 
-echoerr "INFO: Selecting ELB to update"
-STACK_ELBS=($(stack_resource_type_id ${STACK_NAME} "AWS::ElasticLoadBalancing::LoadBalancer"))
-HTTPS_ELBS=($(aws elb describe-load-balancers \
+echoerr "INFO: Finding stack resources"
+STACK_RESOURCES_JSON=$(aws cloudformation list-stack-resources \
     --region ${AWS_REGION} \
-    --load-balancer-names ${STACK_ELBS[@]} \
-    | jq -r ".LoadBalancerDescriptions[] \
-        | select(.ListenerDescriptions[].Listener.Protocol == \"HTTPS\") \
-        | .LoadBalancerName"))
+    --stack-name "${STACK_NAME}" \
+    --query "StackResourceSummaries[]")
+STACK_RESOURCE_TYPES=($(echo ${STACK_RESOURCES_JSON} \
+    | jq -r '.[].ResourceType'))
 
-[[ ${#HTTPS_ELBS[@]} -gt 1 ]] \
-    && echo "Choose an ELB to update:" \
-    && ELB_NAME=$(choose ${HTTPS_ELBS[@]}) \
-    || ELB_NAME=${HTTPS_ELBS}
+# ELB or ELBv2?
+if contains AWS::ElasticLoadBalancingV2::LoadBalancer ${STACK_RESOURCE_TYPES[@]}; then
+    echoerr "INFO: Finding Listeners to update"
+    ELB_LISTENERS=($(echo ${STACK_RESOURCES_JSON} | jq -r '.[] | select(.ResourceType == "AWS::ElasticLoadBalancingV2::Listener") | .LogicalResourceId'))
 
-echoerr "INFO: Setting ELB '${ELB_NAME}' with new certificate"
-aws elb set-load-balancer-listener-ssl-certificate \
-    --region ${AWS_REGION} \
-    --load-balancer-name ${ELB_NAME} \
-    --load-balancer-port ${ELB_PORT} \
-    --ssl-certificate-id ${IAM_CERT_ARN}
+    if [[ ${#ELB_LISTENERS[@]} -gt 1 ]]; then
+        # Try to find a Listener labelled as "https"
+        for listener in ${ELB_LISTENERS[@]}; do
+            if [[ ${listener} =~ [HTTPS|https] ]]; then
+                ELB_LISTENER=${listener}
+            fi
+        done
+        if [[ -z ${ELB_LISTENER-} ]]; then
+            echoerr "Choose the Listener to update:" \
+            ELB_LISTENER=$(choose ${ELB_LISTENERS[@]})
+        fi
+    else
+        ELB_LISTENER=${ELB_LISTENERS}
+    fi
+
+    ELB_LISTENER_ARN=$(echo ${STACK_RESOURCES_JSON} | jq -r ".[] | select(.LogicalResourceId == \"${ELB_LISTENER}\") | .PhysicalResourceId")
+    echoerr "INFO: Found Listener: '${ELB_LISTENER_ARN}'"
+
+    DEFAULT_CERTIFICATE=$(aws elbv2 describe-listener-certificates --listener-arn ${ELB_LISTENER_ARN} \
+        | jq -r '.Certificates[] | select(.IsDefault == true) | .CertificateArn')
+    echoerr "INFO: Found certificate to replace: '${DEFAULT_CERTIFICATE}'"
+
+    if [[ ${DEFAULT_CERTIFICATE} == ${IAM_CERT_ARN} ]]; then
+        echoerr "ERROR: Can not replace a certificate with itself"
+        exit 1
+    fi
+
+    echoerr "INFO: Setting default certificate"
+    aws elbv2 modify-listener --listener-arn ${ELB_LISTENER_ARN} --certificates CertificateArn=${IAM_CERT_ARN}
+else
+    STACK_ELBS=($(stack_resource_type_id ${STACK_NAME} "AWS::ElasticLoadBalancing::LoadBalancer"))
+    HTTPS_ELBS=($(aws elb describe-load-balancers \
+        --region ${AWS_REGION} \
+        --load-balancer-names ${STACK_ELBS[@]} \
+        | jq -r ".LoadBalancerDescriptions[] \
+            | select(.ListenerDescriptions[].Listener.Protocol == \"HTTPS\") \
+            | .LoadBalancerName"))
+
+    [[ ${#HTTPS_ELBS[@]} -gt 1 ]] \
+        && echo "Choose an ELB to update:" \
+        && ELB_NAME=$(choose ${HTTPS_ELBS[@]}) \
+        || ELB_NAME=${HTTPS_ELBS}
+
+    echoerr "INFO: Setting ELB '${ELB_NAME}' with new certificate"
+    aws elb set-load-balancer-listener-ssl-certificate \
+        --region ${AWS_REGION} \
+        --load-balancer-name ${ELB_NAME} \
+        --load-balancer-port ${ELB_PORT} \
+        --ssl-certificate-id ${IAM_CERT_ARN}
+fi
 

--- a/bin/elb-certificate-update
+++ b/bin/elb-certificate-update
@@ -6,11 +6,12 @@
 source $(dirname $0)/../moon.sh
 
 if [[ $# -lt 1 ]]; then
-    echoerr "Usage: $(basename $0) ENVIRONMENT [CERTIFICATE_NAME]"
+    echoerr "Usage: $(basename $0) ENVIRONMENT [CERTIFICATE_NAME] [ELB_LOGICAL_ID]"
     exit 0
 else
     ENVIRONMENT=$1
     IAM_CERT_NAME=${2-}
+    ELB_LOGICAL_ID=${3-}
 fi
 
 STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
@@ -58,10 +59,19 @@ if contains AWS::ElasticLoadBalancingV2::LoadBalancer ${STACK_RESOURCE_TYPES[@]}
     echoerr "INFO: Finding Listeners to update"
     ELB_LISTENERS=($(echo ${STACK_RESOURCES_JSON} | jq -r '.[] | select(.ResourceType == "AWS::ElasticLoadBalancingV2::Listener") | .LogicalResourceId'))
 
-    if [[ ${#ELB_LISTENERS[@]} -gt 1 ]]; then
+    if [[ ${ELB_LOGICAL_ID-} ]]; then
+        if contains ${ELB_LOGICAL_ID} ${ELB_LISTENERS[@]-} 2>/dev/null; then
+            echoerr "INFO: Found defined Listener"
+            ELB_LISTENER=${ELB_LOGICAL_ID}
+        else
+            echoerr "ERROR: Listener '${ELB_LOGICAL_ID}' is not a resource of '${STACK_NAME}'"
+            exit 1
+        fi
+    elif [[ ${#ELB_LISTENERS[@]} -gt 1 ]]; then
         # Try to find a Listener labelled as "https"
         for listener in ${ELB_LISTENERS[@]}; do
             if [[ ${listener} =~ [HTTPS|https] ]]; then
+                echoerr "INFO: Found HTTPS Listener: '${listener}'"
                 ELB_LISTENER=${listener}
             fi
         done
@@ -70,15 +80,16 @@ if contains AWS::ElasticLoadBalancingV2::LoadBalancer ${STACK_RESOURCE_TYPES[@]}
             ELB_LISTENER=$(choose ${ELB_LISTENERS[@]})
         fi
     else
+        echoerr "INFO: Using default Listener"
         ELB_LISTENER=${ELB_LISTENERS}
     fi
 
     ELB_LISTENER_ARN=$(echo ${STACK_RESOURCES_JSON} | jq -r ".[] | select(.LogicalResourceId == \"${ELB_LISTENER}\") | .PhysicalResourceId")
-    echoerr "INFO: Found Listener: '${ELB_LISTENER_ARN}'"
+    echoerr "INFO: Listener ARN: '${ELB_LISTENER_ARN}'"
 
     DEFAULT_CERTIFICATE=$(aws elbv2 describe-listener-certificates --listener-arn ${ELB_LISTENER_ARN} \
         | jq -r '.Certificates[] | select(.IsDefault == true) | .CertificateArn')
-    echoerr "INFO: Found certificate to replace: '${DEFAULT_CERTIFICATE}'"
+    echoerr "INFO: Found default certificate ARN: '${DEFAULT_CERTIFICATE}'"
 
     if [[ ${DEFAULT_CERTIFICATE} == ${IAM_CERT_ARN} ]]; then
         echoerr "ERROR: Can not replace a certificate with itself"


### PR DESCRIPTION
As v2 Load Balancers are constructed differently from the 'ol v1, the certificate update script had to become a little bloated.. This tool only updates the default certificate, i.e. the one provisioned by the stack template, and not one added after the fact. To make this automation usable an extra input parameter was created to allow the balancer ID to be defined if there are multiple front ends. Noting that the this parameter is only valid for v2 balancers. I cbf updating the old ways because they currently work for our needs.