### PR TITLE
Fix stack param updating

### DIFF
--- a/bin/stack-output-list
+++ b/bin/stack-output-list
@@ -1,0 +1,1 @@
+stack-parameter-list

--- a/bin/stack-parameter-list
+++ b/bin/stack-parameter-list
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+#
+#
+
+source $(dirname $0)/../moon.sh
+
+BASENAME=$(basename $0)
+
+if [[ $# -lt 1 ]]; then
+    echoerr "Usage: ${BASENAME} ENVIRONMENT"
+    exit
+else
+    export ENVIRONMENT=$1
+fi
+
+STACK_NAME="${APP_NAME}-${ENVIRONMENT}"
+
+COMPONENTS=(output parameter)
+COMPONENT=$(echo ${BASENAME} | sed -e 's/stack-//' -e 's/-list//')
+
+if ! contains ${COMPONENT} ${COMPONENTS[@]}; then
+    echoerr "FATAL: Unsupported option '${COMPONENT}'"
+    exit 255
+fi
+
+stack_list_${COMPONENT} ${STACK_NAME}
+

--- a/lib/aws/stack.sh
+++ b/lib/aws/stack.sh
@@ -67,6 +67,30 @@ stack_list_others () {
     done
 }
 
+stack_list_output () {
+    local stack_name=$1
+
+    aws cloudformation describe-stacks \
+        --region ${AWS_REGION} \
+        --stack-name ${stack_name} \
+        | jq -r '.Stacks[].Outputs[].OutputKey' \
+        | sort
+
+    pipe_failure ${PIPESTATUS[@]}
+}
+
+stack_list_parameter () {
+    local stack_name=$1
+
+    aws cloudformation describe-stacks \
+        --region ${AWS_REGION} \
+        --stack-name ${stack_name} \
+        | jq -r '.Stacks[].Parameters[].ParameterKey' \
+        | sort
+
+    pipe_failure ${PIPESTATUS[@]}
+}
+
 stack_name_from_vpc_id () {
     # Return the ${stack_name} of ${vpc_id}
     local vpc_id=$1
@@ -116,7 +140,10 @@ stack_parameter_set () {
         --parameters "[${parameter_json#,}]" \
         --use-previous-template \
         --capabilities CAPABILITY_IAM \
-        >/dev/null
+        >/dev/null \
+        && aws cloudformation wait stack-update-complete \
+            --region ${AWS_REGION} \
+            --stack-name ${stack_name}
 
     return $?
 }

--- a/lib/aws/stack.sh
+++ b/lib/aws/stack.sh
@@ -134,6 +134,7 @@ stack_parameter_set () {
         fi
     done
 
+    echoerr "INFO: Updating '${stack_name}'"
     aws cloudformation update-stack \
         --region ${AWS_REGION} \
         --stack-name ${stack_name} \
@@ -141,6 +142,7 @@ stack_parameter_set () {
         --use-previous-template \
         --capabilities CAPABILITY_IAM \
         >/dev/null \
+        && echoerr "INFO: Waiting for update to complete" \
         && aws cloudformation wait stack-update-complete \
             --region ${AWS_REGION} \
             --stack-name ${stack_name}


### PR DESCRIPTION
1) I needed the ability to see available parameters easily for a stack
2) Only one stack update may happen at any one time, so we should block by default until a change has completed to avoid race conditions else where.