### PR TITLE
Fix indented list items in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ Moonshell tries to adhere to Linux FHS best practice:
 
 * etc/
 
-      * completion.d/ - Bash completion functions suffixed with `.sh`
+  * completion.d/ - Bash completion functions suffixed with `.sh`
 
-      * profile.d/ - Definitions of variables and other statically set things
+  * profile.d/ - Definitions of variables and other statically set things
 
 * usr/ - Extra supporting files for applications
 


### PR DESCRIPTION
The indented list items are being interpreted by GitHub as a code block:

![image](https://user-images.githubusercontent.com/943942/228534662-fe64aca6-854b-4d44-8268-1fd3d0398046.png)

This fixes the issue so that they are rendered correctly as list items:

![image](https://user-images.githubusercontent.com/943942/228534807-c73f8e6c-342a-4784-8e14-43fa86e50b67.png)
